### PR TITLE
feat: use readable words in compact format

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,15 @@ Minitest::Reporters.use! [
 
 #### Compact Mode (Optimized for LLMs)
 ```
-R t15 d2.3s p12 f2 e1 s0
-REG +1 -0
-F user_test.rb:45 validation fails
-E api_test.rb:12 connection timeout
+15 tests,12 passed,2 failures,1 error,0 skips 2.3s
+reg: 1 new,0 fixed
+FAIL user_test.rb:45 validation fails
+ERROR api_test.rb:12 connection timeout
 ```
 
-Format: `R t{total} d{duration} p{pass} f{fail} e{error} s{skip}`
-- `R` = Result summary line
-- `F/E/S` = Individual failure/error/skip lines
-- `REG +X -Y` = Regression summary (X new failures, Y fixes)
+- Summary line: `{total} tests,{passed} passed,{failures} failures,{errors} errors,{skips} skips {duration}`
+- `FAIL/ERROR/SKIP` = Individual failure/error/skip lines
+- `reg: X new,Y fixed` = Regression summary (X new failures, Y fixes)
 
 #### Verbose Mode (Human-friendly)
 ```

--- a/lib/minitest/reporters/llm_reporter.rb
+++ b/lib/minitest/reporters/llm_reporter.rb
@@ -62,21 +62,21 @@ module Minitest
       end
 
       def report_compact(total, passes, fails_ct, errors_ct, skips_ct)
-        puts "R t#{total} d#{format_time(llm_total_time)} p#{passes} f#{fails_ct} e#{errors_ct} s#{skips_ct}"
+        puts "#{total} tests,#{passes} passed,#{fails_ct} failures,#{errors_ct} errors,#{skips_ct} skips #{format_time(llm_total_time)}"
 
         show_regressions_compact
 
         # Show failures
         if fails_ct.positive?
           tests_list.select { |t| t.failure && !t.skipped? && !t.error? }.each do |test|
-            puts "F #{format_test_location_compact(test)}"
+            puts "FAIL #{format_test_location_compact(test)}"
           end
         end
 
         # Show errors
         if errors_ct.positive?
           tests_list.select { |t| t.failure && t.error? }.each do |test|
-            puts "E #{format_test_location_compact(test)}"
+            puts "ERROR #{format_test_location_compact(test)}"
           end
         end
 
@@ -84,7 +84,7 @@ module Minitest
         return unless skips_ct.positive?
 
         tests_list.select(&:skipped?).each do |test|
-          puts "S #{format_test_location_compact(test)}"
+          puts "SKIP #{format_test_location_compact(test)}"
         end
       end
 
@@ -301,7 +301,7 @@ module Minitest
           fixes += 1 if %w[fail error skip].include?(previous_status) && status == 'pass'
         end
 
-        puts "REG +#{new_failures} -#{fixes}" if new_failures.positive? || fixes.positive?
+        puts "reg: #{new_failures} new,#{fixes} fixed" if new_failures.positive? || fixes.positive?
       end
 
       def test_key_to_location(test_key)

--- a/test/minitest/reporters/llm_reporter_test.rb
+++ b/test/minitest/reporters/llm_reporter_test.rb
@@ -150,7 +150,7 @@ class LlmReporterIntegrationTest < Minitest::Test
                                 })
 
     reporter.send(:show_regressions_compact)
-    assert_includes io.string, 'REG +1 -2'
+    assert_includes io.string, 'reg: 1 new,2 fixed'
   end
 
   def test_toml_arrays_are_valid


### PR DESCRIPTION
## Summary
- Replace cryptic single-char prefixes (`R`,`F`,`E`,`S`,`REG`) with readable words (`FAIL`,`ERROR`,`SKIP`,`reg:`)
- Summary line now reads `15 tests,12 passed,2 failures,1 error,0 skips 2.3s` instead of `R t15 d2.3s p12 f2 e1 s0`
- No space after commas to stay token-efficient

## Test plan
- [x] `bundle exec rake test` — 14 tests pass